### PR TITLE
feat: include response headers to log correlation id

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -101,6 +101,7 @@ export class CommercetoolsClient {
     return {
       host: options.host!,
       enableRetry: true,
+      includeResponseHeaders: true,
       retryConfig: {
         maxRetries: 2,
         retryDelay: 300,


### PR DESCRIPTION
For a POC for Frasers Group we would like to log the correlation id's of Commercetools. This PR makes it available by enabling the `includeResponseHeaders`